### PR TITLE
179539687-SolanaRpcRuby-Api-Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 
 ## 1.1.0
 * Add websockets connection to gem.
+
+## 1.1.1
+* Fix SolanaRpcRuby::ApiError

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@
 
 ## 1.1.1
 * Fix SolanaRpcRuby::ApiError occurring when websocket program runs for too long
-(#<SolanaRpcRuby::ApiError: NoMethodError undefined methodping)
+(#<SolanaRpcRuby::ApiError: NoMethodError undefined method ping)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@
 * Add websockets connection to gem.
 
 ## 1.1.1
-* Fix SolanaRpcRuby::ApiError
+* Fix SolanaRpcRuby::ApiError occurring when websocket program runs for too long
+(#<SolanaRpcRuby::ApiError: NoMethodError undefined methodping)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solana_rpc_ruby (1.1.0)
+    solana_rpc_ruby (1.1.1)
       faye-websocket (~> 0.11)
 
 GEM

--- a/lib/solana_rpc_ruby/version.rb
+++ b/lib/solana_rpc_ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolanaRpcRuby
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
### Summary

get rid of SolanaRpcRuby-Api-Error on the cluster requests