### PR TITLE
184529687 - fix get block method

### DIFF
--- a/lib/solana_rpc_ruby/helper_methods.rb
+++ b/lib/solana_rpc_ruby/helper_methods.rb
@@ -3,14 +3,15 @@ module SolanaRpcRuby
   module HelperMethods
     # Checks if the object is nil or empty.
     # 
-    # @param object [String, Array, Hash]
+    # @param object [String, Array, Hash, Integer, NilClass]
     # 
     # @return [Boolean]
     def blank?(object)
-      raise ArgumentError, 'Object must be a String, Array or Hash or nil class.'\
-        unless object.is_a?(String) || object.is_a?(Array) || object.is_a?(Hash) || object.nil?
-  
-      object.nil? || object.empty?
+      unless [String, Array, Hash, Integer, NilClass].include? object.class
+        raise ArgumentError, 'Object must be a String, Array or Hash or Integer or nil class.'
+      end
+
+      object.nil? || object.try(:empty?)
     end
 
     # Creates method name to match names required by Solana RPC JSON.

--- a/lib/solana_rpc_ruby/methods_wrapper.rb
+++ b/lib/solana_rpc_ruby/methods_wrapper.rb
@@ -108,22 +108,26 @@ module SolanaRpcRuby
     # @param commitment [String]
     #
     # @return [Response, ApiError] Response when success, ApiError on failure.
-    def get_block(slot, encoding: '', transaction_details: '', rewards: true, commitment: nil)
+    def get_block(slot, params = {})
+      params[:rewards] ||= true
+      params[:max_supported_transaction_version] ||= 0
+
       http_method = :post
-      method =  create_method_name(__method__)
+      method = create_method_name(__method__)
 
-      params = []
+      params_build = {}
+      params_build['encoding'] = params[:encoding] unless blank?(params[:encoding])
+      params_build['transactionDetails'] = params[:transaction_details] unless blank?(params[:transaction_details])
+      params_build['rewards'] = params[:rewards] unless params[:rewards].nil?
+      params_build['commitment'] = params[:commitment] unless blank?(params[:commitment])
+      params_build['maxSupportedTransactionVersion'] =
+        params[:max_supported_transaction_version] unless blank?(params[:max_supported_transaction_version])
 
-      params_hash = {}
-      params_hash['encoding'] = encoding unless blank?(encoding)
-      params_hash['transactionDetails'] = transaction_details unless blank?(transaction_details)
-      params_hash['rewards'] = rewards unless rewards.nil?
-      params_hash['commitment'] = commitment unless blank?(commitment)
+      params_request = []
+      params_request << slot
+      params_request << params_build unless params_build.empty?
 
-      params << slot
-      params << params_hash unless params_hash.empty?
-
-      body = create_json_body(method, method_params: params)
+      body = create_json_body(method, method_params: params_request)
 
       send_request(body, http_method)
     end

--- a/spec/lib/solana_rpc_ruby/helper_methods_spec.rb
+++ b/spec/lib/solana_rpc_ruby/helper_methods_spec.rb
@@ -17,8 +17,7 @@ describe SolanaRpcRuby::RequestBody do
     end
 
     it 'raises an error when incorrect object passed in' do
-      message = /Object must be a String, Array or Hash or nil class./
-      expect { blank?(1) } .to raise_error(ArgumentError, message)
+      message = /Object must be a String, Array or Hash or Integer or nil class./
       expect { blank?(true) } .to raise_error(ArgumentError, message)
       expect { blank?(false) } .to raise_error(ArgumentError, message)
     end


### PR DESCRIPTION
### Summary

Upon `getBlock` request method (https://docs.solana.com/api/http#getblock) it is required to attach the `maxSupportedTransactionVersion` param. This Pull Request applies the changes to `get_block` method and as default it adds `maxSupportedTransactionVersion` with value 0.

https://www.pivotaltracker.com/story/show/184529687
